### PR TITLE
Remove warnings

### DIFF
--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -27,10 +27,10 @@ impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         match self {
             Error::Other(e) => internal_error(e).into_response(),
-            Error::HttpClient(error) => todo!(),
-            Error::Io(error) => todo!(),
-            Error::Deserialization(error) => todo!(),
-            Error::Sqlite(error) => todo!(),
+            Error::HttpClient(_error) => todo!(),
+            Error::Io(_error) => todo!(),
+            Error::Deserialization(_error) => todo!(),
+            Error::Sqlite(_error) => todo!(),
         }
     }
 }


### PR DESCRIPTION
Something I missed at https://github.com/mainmatter/reStations/pull/7: fix the warnings thrown by the compiler, as they pollute the output and make it more difficult to read errors.