### PR TITLE
[WIP] Stream "problems" along with station records

### DIFF
--- a/web/src/controllers/stations.rs
+++ b/web/src/controllers/stations.rs
@@ -1,6 +1,10 @@
+use std::task::Poll;
+
+use axum::body::Bytes;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum_streams::StreamBodyAs;
+use hyper::body::Frame;
 // TODO figure out why only using types:: doesn't work here
 use crate::state::SharedAppState;
 use crate::types::station_record::StationRecord;
@@ -8,6 +12,7 @@ use axum::extract::State;
 use futures_util::TryStreamExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+use futures_util::TryStream;
 
 use super::super::db;
 
@@ -28,6 +33,82 @@ pub async fn list(State(app_state): State<SharedAppState>) -> impl IntoResponse 
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "application/json")
-        .body(StreamBodyAs::json_array_with_errors(stations_stream))
+        .body(JsonStreamBody::new(stations_stream))
+        // .body(StreamBodyAs::json_array_with_errors(stations_stream))
+        // .body(JsonStreamBody {})
         .unwrap()
+}
+struct JsonStreamBody<S> {
+    stream: S,
+    problems: Vec<Problem>,
+    current_state: JsonStreamBodyState,
+}
+
+enum JsonStreamBodyState {
+    Initial,
+    Stations,
+    Problems,
+    ProblemsDone,
+    End,
+}
+
+impl<S> JsonStreamBody<S> {
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            problems: vec![],
+            current_state: JsonStreamBodyState::Initial,
+        }
+    }
+}
+
+impl<I: serde::Serialize, S: futures_util::TryStream<Item = I> + std::marker::Unpin> axum::body::HttpBody for JsonStreamBody<S> {
+    type Data = axum::body::Bytes;
+    type Error = std::convert::Infallible;
+    
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match this.current_state {
+            // initial state: send `{ "places": [`
+            JsonStreamBodyState::Initial => {
+                this.current_state = JsonStreamBodyState::Stations;
+                Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(br#"{ "places": ["#)))))
+            },
+            // streaming: send results and commas
+            JsonStreamBodyState::Stations => {
+                let stream_pinned = std::pin::Pin::new(&mut this.stream);
+            // ) -> Poll<Option<Result<Self::Ok, Self::Error>>>;
+                match stream_pinned.try_poll_next(cx) {
+                    Poll::Ready(None) => {
+                        // streaming_done: send `], "problems": [`
+                        this.current_state = JsonStreamBodyState::Problems;
+                        Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(br#"], "problems": ["#)))))
+                    },
+                    Poll::Ready(msg) => {
+                        todo!()
+                    },
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+            // sending_problems: send problems and commas
+            JsonStreamBodyState::Problems => todo!(),
+            // problems_done: send `] }`
+            JsonStreamBodyState::ProblemsDone => todo!(),
+            // end: return None
+            JsonStreamBodyState::End => todo!(),
+        }
+    }
+}
+/*
+    { "places": [112312, 123123 ,123123 ,123 , ❌, 123123 312,31231, 420,123 , ❌, 12313,], "problems": [{idx: 0, e: "wrong stuff"}] };
+
+*/
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Problem {
+    code: String,
+    title: String,
 }


### PR DESCRIPTION
At https://github.com/mainmatter/reStations/pull/17, we removed an `unwrap` call, allowing the processing of potential errors arising from reading stations from DB. This is an extremely unlikely occurrence, but we are doing it as part of the learning process. The solution ended up involving a `StreamBodyAs::json_array_with_errors` call, which would crash at runtime if any errors appear.

Now it's time to handle those errors properly. In the OSDM spec, we see that the `/places` endpoint can return "problems" as well as the expected "places" ([link](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.4/OSDM-online-api-v3.4.0.yml&nocors#tag/Master-Data/operation/getPlaces)). The idea here is to return the stations as "places" and any observed errors as "problems".

For this, we need our own version of `StreamBodyAs::json_array_with_errors`. A stream adapter that receives results and puts them in either "places" or "problems" as appropriate. As the stream emits `Ok` results, these are immediately emitted as places, serialized in JSON. When an `Err` comes through, this is put in a `problems` vectors. When all results have been received, the collected problems are returned, serialized in JSON.