### PR TITLE
First stab at test that uses the DB

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -7,7 +7,7 @@ use axum::serve;
 use error::Error;
 use restations_config::{get_env, load_config, Config};
 
-mod db;
+pub mod db;
 
 use tokio::{net::TcpListener, sync::mpsc};
 use tracing::{info, instrument};

--- a/web/src/test_helpers/mod.rs
+++ b/web/src/test_helpers/mod.rs
@@ -183,6 +183,7 @@ impl BodyExt for Body {
 pub struct TestContext {
     /// The application that is being tested.
     pub app: Router,
+    pub pool: Arc<db::Pool>,
 }
 
 /// Sets up a test and returns a [`TestContext`].
@@ -194,9 +195,13 @@ pub async fn setup() -> TestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
     let _config = init_config.get_or_init(|| load_config(&Environment::Test).unwrap());
 
+    let pool = Arc::new(db::create_pool());
     let app = init_routes(AppState {
-        pool: Arc::new(db::create_pool()),
+        pool: pool.clone(),
     });
 
-    TestContext { app }
+    TestContext {
+        app,
+        pool,
+    }
 }

--- a/web/tests/api/stations_test.rs
+++ b/web/tests/api/stations_test.rs
@@ -2,7 +2,10 @@ use googletest::prelude::{assert_that,eq};
 use restations_macros::test;
 use restations_web::test_helpers::{BodyExt, RouterExt, TestContext};
 
+use restations_web::db;
 use restations_web::controllers::stations::StationsListResponse;
+
+use restations_web::types::station_record::StationRecord;
 
 #[test]
 async fn test_list_empty(context: &TestContext) {
@@ -10,4 +13,28 @@ async fn test_list_empty(context: &TestContext) {
     let stations: StationsListResponse = response.into_body().into_json().await;
 
     assert_that!(stations, eq(&StationsListResponse::new()));
+}
+
+#[test]
+async fn test_list_single_record(context: &TestContext) {
+    let dbconn = context.pool.get().unwrap();
+    let _ = db::create_tables(&dbconn)
+        .expect("Could not create DB tables");
+    let test_station = StationRecord {
+        id: 1,
+        name: String::from("Test Station"),
+        slug: String::from("test-station"),
+        ..Default::default()
+    };
+    let _ = db::insert_station(&dbconn, &test_station)
+        .expect("Could not insert station in DB");
+
+    let response = context.app.request("/stations").send().await;
+    let stations: StationsListResponse = response.into_body().into_json::<StationsListResponse>().await;
+
+    assert_that!(stations.len(), eq(1));
+    let station = &stations[0];
+    assert_that!(station.id, eq(1));
+    assert_that!(station.name, eq("Test Station"));
+    assert_that!(station.slug, eq("test-station"));
 }


### PR DESCRIPTION
Working on https://github.com/mainmatter/reStations/pull/28, I decided to write a test... then decided it was its own whole thing and it would be better served by separating into a dedicated PR.

My main difficulty was with how to access the state of the app from the test, as I don't think it can be accessed via the router with `context.app.{something}`, or at least not cleanly. Eventually I realised I could just add it to the `TestContext` and access is there. Does this sound ok?

The DB initialization (`db::create_tables`) can probably be generalised into a macro or something. For now I think it's fine in the test.