### PR TITLE
Map place id to station UIC

### DIFF
--- a/web/src/controllers/places.rs
+++ b/web/src/controllers/places.rs
@@ -1,7 +1,7 @@
 use crate::db;
 use crate::state::SharedAppState;
-use crate::types::station_record::StationRecord;
 use crate::types::osdm::*;
+use crate::types::station_record::StationRecord;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
@@ -23,13 +23,13 @@ impl IntoResponse for PlacesShowResponse {
 #[axum::debug_handler]
 pub async fn show(
     State(app_state): State<SharedAppState>,
-    Path(id): Path<u64>,
+    Path(place_id): Path<String>, // TODO: fix uic type at sync stage, like latitude and longitude
 ) -> PlacesShowResponse {
     let conn = app_state.pool.get().unwrap();
 
-    match db::find_station(&conn, id) {
+    match db::find_station(&conn, &place_id) {
         Ok(station) => show_found_station(station),
-        Err(db::DbError::RecordNotFound(_msg)) => show_not_found(id),
+        Err(db::DbError::RecordNotFound(_msg)) => show_not_found(place_id),
         _ => todo!("Unexpected error at places::show"),
     }
 }
@@ -50,7 +50,8 @@ fn show_found_station(station: StationRecord) -> PlacesShowResponse {
     };
 
     let place = OsdmPlace {
-        id: station.id,
+        // TODO: fix uic type at sync stage, like latitude and longitude
+        id: station.uic.parse::<i64>().expect("Failed to parse uic"),
         object_type: "StopPlace".into(),
         alternative_ids: vec![],
         geo_position,
@@ -63,10 +64,10 @@ fn show_found_station(station: StationRecord) -> PlacesShowResponse {
     PlacesShowResponse::Ok(response)
 }
 
-fn show_not_found(id: u64) -> PlacesShowResponse {
+fn show_not_found(place_id: String) -> PlacesShowResponse {
     let api_problem = OsdmProblem {
         code: String::from("not-found"),
-        title: String::from(format!("Could not find place with id #{}", id)),
+        title: String::from(format!("Could not find place with id #{}", place_id)),
     };
     PlacesShowResponse::NotFound(api_problem)
 }

--- a/web/src/db.rs
+++ b/web/src/db.rs
@@ -44,18 +44,19 @@ pub fn insert_station(db: &Connection, record: &StationRecord) -> Result<usize, 
     )?)
 }
 
-pub fn find_station(db: &Connection, id: u64) -> Result<StationRecord, DbError> {
-    let mut stmt = db.prepare("SELECT * from stations where id=?")?;
+pub fn find_station(db: &Connection, place_id: &String) -> Result<StationRecord, DbError> {
+    // OSDM place id maps to station's uic
+    let mut stmt = db.prepare("SELECT * from stations where uic=?")?;
 
     let columns = columns_from_statement(&stmt);
-    let result = stmt.query_row([id], |row| {
+    let result = stmt.query_row([place_id], |row| {
         Ok(from_row_with_columns::<StationRecord>(row, &columns).unwrap())
     });
 
     match result {
         Ok(result) => Ok(result),
         Err(rusqlite::Error::QueryReturnedNoRows) => Err(DbError::RecordNotFound(String::from(
-            format!("Could not find station with id #{}", id),
+            format!("Could not find station with uic #{}", &place_id),
         ))),
         _ => todo!("Unexpected error at db::find_station"),
     }

--- a/web/tests/api/places_test.rs
+++ b/web/tests/api/places_test.rs
@@ -2,8 +2,8 @@ use googletest::prelude::{assert_that, eq};
 use restations_macros::test;
 use restations_web::test_helpers::{BodyExt, RouterExt, TestContext};
 
-use restations_web::types::osdm::*;
 use restations_web::db;
+use restations_web::types::osdm::*;
 
 use restations_web::types::station_record::StationRecord;
 
@@ -11,25 +11,26 @@ use restations_web::types::station_record::StationRecord;
 async fn test_show_ok(context: &TestContext) {
     let dbconn = context.pool.get().unwrap();
     let _ = db::create_tables(&dbconn).expect("Could not create DB tables");
+    // Lisbon Santa Apolónia
     let test_station = StationRecord {
-        id: 1,
-        latitude: String::from("40.416729"),
-        longitude: String::from("-3.703339"),
+        uic: String::from("9430007"),
+        latitude: String::from("38.71387"),
+        longitude: String::from("-9.122271"),
         ..Default::default()
     };
     let _ = db::insert_station(&dbconn, &test_station).expect("Could not insert station in DB");
 
-    let response = context.app.request("/places/1").send().await;
+    let response = context.app.request("/places/9430007").send().await;
     assert_that!(response.status(), eq(200));
 
     let api_place: OsdmPlaceResponse = response.into_body().into_json::<OsdmPlaceResponse>().await;
 
     assert_that!(api_place.places.len(), eq(1));
     let place = &api_place.places[0];
-    assert_that!(place.id, eq(1));
+    assert_that!(place.id, eq(9430007));
     assert_that!(place.object_type, eq("StopPlace"));
-    assert_that!(place.geo_position.latitude, eq(40.416729));
-    assert_that!(place.geo_position.longitude, eq(-3.703339));
+    assert_that!(place.geo_position.latitude, eq(38.71387));
+    assert_that!(place.geo_position.longitude, eq(-9.122271));
 }
 
 #[test]


### PR DESCRIPTION
Trip and Places [model documentation](https://osdm.io/spec/models/#TripsAndPlaces) states that `using the UIC code set is highly recommended and mandatory for train stations`:

```
StopPlace: represent a place where a train or a bus stops. It is obviously the most relevant type for OSDM. StopPlaces can be indicated as codes from different code sets. As with other code list based representations in the API, using the UIC code set is highly recommended and mandatory for train stations.
```

Addresses on-going discussion regarding the OSDM spec on https://github.com/mainmatter/reStations/issues/21

