### PR TITLE
Convert all OSDM key names to camelCase

### DIFF
--- a/web/src/types/osdm.rs
+++ b/web/src/types/osdm.rs
@@ -15,6 +15,7 @@ pub struct OsdmLink {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OsdmPlace {
     pub id: String,
     pub object_type: String,


### PR DESCRIPTION
When writing these structs, we forgot that OSDM uses camelCase. Fortunately, this one struct appears to be the only one affected so far (others coming in a different PR that will need to be rebased). Also fortunately, it's just a matter of a serde declaration.