### PR TITLE
Include place names

### DIFF
--- a/web/src/controllers/places.rs
+++ b/web/src/controllers/places.rs
@@ -99,6 +99,7 @@ fn station_to_osdm_place(station: StationRecord) -> OsdmPlace {
     OsdmPlace {
         id: station.uic,
         object_type: "StopPlace".into(),
+        name: station.name,
         alternative_ids: vec![],
         geo_position,
         _links: vec![],

--- a/web/src/types/osdm.rs
+++ b/web/src/types/osdm.rs
@@ -23,6 +23,7 @@ pub struct OsdmLink {
 pub struct OsdmPlace {
     pub id: String,
     pub object_type: String,
+    pub name: String,
     pub alternative_ids: Vec<String>,
     pub geo_position: Option<OsdmGeoPosition>,
     pub _links: Vec<OsdmLink>,


### PR DESCRIPTION
Currently this server doesn't strike me as very useful. For example, this is a response. The place is the station Lisboa Santa Apolónia:
```
{
  "places": [
    {
      "id": "9430007",
      "objectType": "StopPlace",
      "alternativeIds": [],
      "geoPosition": {
        "latitude": 38.71387,
        "longitude": -9.122271
      },
      "links": []
    }
  ]
}

```

Contains an id, a lat/long... and nothing else? Perhaps it should include a place name?

The Swagger description is ambiguous on this one. It lists only the fields we return, but doesn't preclude the existence of other fields, since Swagger defines `additionalProperties` as `true` by default (https://swagger.io/specification/v3/?sbsearch=additionalProperties). But that's not helpful because it doesn't tell us what other properties would look like.

But then there's the Redoc description. The examples on the sidebar have similar information to the above... but the schema does show additional properties like `name`, `countryCode` and others: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.4/OSDM-online-api-v3.4.0.yml&nocors#tag/Places/operation/postPlaces.

Also I've been playing with the demo app at https://github.com/UnionInternationalCheminsdeFer/OSDM-demo-app. This does expect a `name` field, and I can confirm it reads it correctly if reStations offers it.

Therefore, I think we should add additional fields, starting with the `name`.