### PR TITLE
Ensure that place ids are URNs

### DIFF
--- a/web/src/controllers/places.rs
+++ b/web/src/controllers/places.rs
@@ -97,7 +97,7 @@ fn station_to_osdm_place(station: StationRecord) -> OsdmPlace {
     };
 
     OsdmPlace {
-        id: station.uic,
+        id: format!("urn:uic:stn:{}", station.uic),
         object_type: "StopPlace".into(),
         name: station.name,
         alternative_ids: vec![],

--- a/web/tests/api/places_test.rs
+++ b/web/tests/api/places_test.rs
@@ -122,7 +122,7 @@ async fn test_show_ok(context: &TestContext) {
 
     assert_that!(api_place.places.len(), eq(1));
     let place = &api_place.places[0];
-    assert_that!(place.id, eq("9430007"));
+    assert_that!(place.id, eq("urn:uic:stn:9430007"));
     assert_that!(place.object_type, eq("StopPlace"));
     assert_that!(
         place.geo_position.as_ref().unwrap(),


### PR DESCRIPTION
As discussed at https://github.com/mainmatter/reStations/pull/58#issuecomment-2706297060

Currently we are returning place ids that are UIC codes. The OSDM spec has this to say about place ids:

> id defining the place. The code is provided as URN, relative URNs are allowed with base path urn:uic:stn '0850000'

The phrasing is confusing. I think it means: "if the id is `0850000`, it will be interpreted as `urn:uic:stn:0850000`". But just to be sure, let's add the prefix explicitly.