### PR TITLE
Add DATABASE_URL to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=sqlite:stations.sqlite.db


### PR DESCRIPTION
We always need this set for local development, and including it in the repo will remove one setup step for newcomers.