### PR TITLE
Add country code

### DIFF
--- a/scripts/sync-data
+++ b/scripts/sync-data
@@ -94,7 +94,6 @@ DELETE FROM stations WHERE uic = "";
 ALTER TABLE stations DROP COLUMN slug;
 ALTER TABLE stations DROP COLUMN uic8_sncf;
 ALTER TABLE stations DROP COLUMN parent_station_id;
-ALTER TABLE stations DROP COLUMN country;
 ALTER TABLE stations DROP COLUMN time_zone;
 ALTER TABLE stations DROP COLUMN is_city;
 ALTER TABLE stations DROP COLUMN is_main_station;

--- a/web/src/controllers/places.rs
+++ b/web/src/controllers/places.rs
@@ -14,7 +14,7 @@ pub struct OsdmGeoPosition {
     pub longitude: f64,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct OsdmLink {
     rel: String,
     href: String,
@@ -22,7 +22,7 @@ pub struct OsdmLink {
     value: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OsdmPlace {
     pub id: String,
@@ -183,4 +183,35 @@ fn render_not_found(place_id: String) -> PlacesResponse {
         title: format!("Could not find place with id #{}", place_id),
     };
     PlacesResponse::NotFound(api_problem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_station_record_to_osdm_place() {
+        let record = StationRecord {
+            id: 8260,
+            uic: String::from("7051430"),
+            name: String::from("London Charing Cross"),
+            latitude: Some(51.508362),
+            longitude: Some(-0.123835),
+            ..StationRecord::default()
+        };
+
+        let place = OsdmPlace::from(record);
+
+        assert_eq!(place, OsdmPlace {
+            id: String::from("urn:uic:stn:7051430"),
+            object_type: String::from("StopPlace"),
+            name: String::from("London Charing Cross"),
+            geo_position: Some(OsdmGeoPosition {
+                latitude: 51.508362,
+                longitude: -0.123835,
+            }),
+            alternative_ids: vec![],
+            _links: Vec::<OsdmLink>::new(),
+        });
+    }
 }

--- a/web/src/controllers/places.rs
+++ b/web/src/controllers/places.rs
@@ -30,6 +30,7 @@ pub struct OsdmPlace {
     pub name: String,
     pub alternative_ids: Vec<String>,
     pub geo_position: Option<OsdmGeoPosition>,
+    pub country_code: Option<String>,
     pub _links: Vec<OsdmLink>,
 }
 
@@ -95,6 +96,7 @@ impl From<StationRecord> for OsdmPlace {
             name: station.name,
             alternative_ids: vec![],
             geo_position,
+            country_code: station.country,
             _links: vec![],
         }
     }
@@ -197,6 +199,7 @@ mod tests {
             name: String::from("London Charing Cross"),
             latitude: Some(51.508362),
             longitude: Some(-0.123835),
+            country: Some(String::from("GB")),
             ..StationRecord::default()
         };
 
@@ -210,6 +213,7 @@ mod tests {
                 latitude: 51.508362,
                 longitude: -0.123835,
             }),
+            country_code: Some(String::from("GB")),
             alternative_ids: vec![],
             _links: Vec::<OsdmLink>::new(),
         });

--- a/web/src/controllers/places.rs
+++ b/web/src/controllers/places.rs
@@ -205,17 +205,20 @@ mod tests {
 
         let place = OsdmPlace::from(record);
 
-        assert_eq!(place, OsdmPlace {
-            id: String::from("urn:uic:stn:7051430"),
-            object_type: String::from("StopPlace"),
-            name: String::from("London Charing Cross"),
-            geo_position: Some(OsdmGeoPosition {
-                latitude: 51.508362,
-                longitude: -0.123835,
-            }),
-            country_code: Some(String::from("GB")),
-            alternative_ids: vec![],
-            _links: Vec::<OsdmLink>::new(),
-        });
+        assert_eq!(
+            place,
+            OsdmPlace {
+                id: String::from("urn:uic:stn:7051430"),
+                object_type: String::from("StopPlace"),
+                name: String::from("London Charing Cross"),
+                geo_position: Some(OsdmGeoPosition {
+                    latitude: 51.508362,
+                    longitude: -0.123835,
+                }),
+                country_code: Some(String::from("GB")),
+                alternative_ids: vec![],
+                _links: Vec::<OsdmLink>::new(),
+            }
+        );
     }
 }

--- a/web/src/db/finders.rs
+++ b/web/src/db/finders.rs
@@ -10,7 +10,7 @@ impl Search {
         println!("Finding all stations");
         let stations = sqlx::query_as!(
            StationRecord,
-           "SELECT id, name, uic, latitude, longitude, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh FROM stations WHERE uic IS NOT NULL"
+           "SELECT id, name, uic, latitude, longitude, country, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh FROM stations WHERE uic IS NOT NULL"
        )
        .fetch_all(db)
        .await?;
@@ -20,7 +20,7 @@ impl Search {
     pub async fn by_name(db: &DbPool, name: &str) -> Result<Vec<StationRecord>, DbError> {
         println!("Searching all stations");
         let pattern = format!("%{}%", name);
-        let stations = sqlx::query_as!(StationRecord, "SELECT id, name, uic, latitude, longitude, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh from stations  WHERE uic IS NOT NULL AND (name like $1 OR info_de like $1 OR info_en like $1 OR info_es like $1 OR info_fr like $1 OR info_it like $1 OR info_nb like $1 OR info_nl like $1 OR info_cs like $1 OR info_da like $1 OR info_hu like $1 OR info_ja like $1 OR info_ko like $1 OR info_pl like $1 OR info_pt like $1 OR info_ru like $1 OR info_sv like $1 OR info_tr like $1 OR info_zh like $1)", pattern)
+        let stations = sqlx::query_as!(StationRecord, "SELECT id, name, uic, latitude, longitude, country, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh from stations  WHERE uic IS NOT NULL AND (name like $1 OR info_de like $1 OR info_en like $1 OR info_es like $1 OR info_fr like $1 OR info_it like $1 OR info_nb like $1 OR info_nl like $1 OR info_cs like $1 OR info_da like $1 OR info_hu like $1 OR info_ja like $1 OR info_ko like $1 OR info_pl like $1 OR info_pt like $1 OR info_ru like $1 OR info_sv like $1 OR info_tr like $1 OR info_zh like $1)", pattern)
               .fetch_all(db)
               .await?;
         Ok(stations)
@@ -29,7 +29,7 @@ impl Search {
     pub async fn by_place_id(db: &DbPool, place_id: &String) -> Result<StationRecord, DbError> {
         sqlx::query_as!(
             StationRecord,
-            "SELECT id, name, uic, latitude, longitude, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh FROM stations WHERE uic = $1",
+            "SELECT id, name, uic, latitude, longitude, country, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh FROM stations WHERE uic = $1",
             place_id
         )
         .fetch_optional(db)

--- a/web/src/db/station_record.rs
+++ b/web/src/db/station_record.rs
@@ -9,6 +9,7 @@ pub struct StationRecord {
     pub uic: String,
     pub latitude: Option<f64>,
     pub longitude: Option<f64>,
+    pub country: Option<String>,
     pub info_de: Option<String>,
     pub info_en: Option<String>,
     pub info_es: Option<String>,


### PR DESCRIPTION
This is the one other property that is trivial to add.

## Open question

Should this be `Option<String>` or just `String`? In other words: should the DB column be nullable? Looking at the source data, it looks like all entries have it, so we could make it not nullable. However it's worth considering if this could come to bite us in the future, if new entries are added that don't have this detail.

## After this

There are the following that should be possible to add, just not as trivially:
- `countryName`: it's not in the source data, but we could map it from the country code through a manually curated list.
- `city`: this looks like it can be obtained by travelling up the `parent_station_id`, but this has tradeoffs and different ways to do it.

I'll create separate tickets for those.