### PR TITLE
Fix Dockerfile

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,24 @@
+name: 'Hello World'
+description: 'Greet someone'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    
+    - run: ./scripts/sync-data
+      shell: bash
+    
+    - run: docker build --tag restations .
+      shell: bash
+    
+    - name: Smoke-test to ensure correctness
+      run: |
+        docker run -d -p 3000:3000 restations
+        sleep 5
+        # check the server runs at all
+        curl --retry 5 --retry-all-errors localhost:3000/places
+        # check Paris Gare de l’Est exists
+        curl localhost:3000/places/8711300 | jq -e '.places.[0] | select (.name=="Paris Gare de l’Est")'
+        # check Paris Gare de l’Est is found for correct location
+        curl -X POST -H "Content-Type: application/json" -d '{"restrictions": {"numberOfResults": 3}, "placeInput": {"geoPosition": {"latitude": 48.877, "longitude": 2.358}}}' localhost:3000/places | jq -e '.places.[] | select (.name=="Paris Gare de l’Est")'
+      shell: bash

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -47,25 +47,9 @@ jobs:
       - name: test
         run: cargo test
 
-  test_docker:
+  smoke_test:
     name: "Smoke-test the Docker image"
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-    
-      - run: ./scripts/sync-data
-    
-      - run: docker build --tag restations .
-
-      - name: Smoke-test to ensure correctness
-        run: |
-          docker run -d -p 3000:3000 restations
-          sleep 5
-          # check the server runs at all
-          curl --retry 5 --retry-all-errors localhost:3000/places
-          # check Paris Gare de l’Est exists
-          curl localhost:3000/places/8711300 | jq -e '.places.[0] | select (.name=="Paris Gare de l’Est")'
-          # check Paris Gare de l’Est is found for correct location
-          curl -X POST -H "Content-Type: application/json" -d '{"restrictions": {"numberOfResults": 3}, "placeInput": {"geoPosition": {"latitude": 48.877, "longitude": 2.358}}}' localhost:3000/places | jq -e '.places.[] | select (.name=="Paris Gare de l’Est")'
+      - uses: ./.github/actions/smoke-test

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -59,7 +59,13 @@ jobs:
     
       - run: docker build --tag restations .
 
-      - run: |
+      - name: Smoke-test to ensure correctness
+        run: |
           docker run -d -p 3000:3000 restations
-          sleep 3
-          curl --retry 5 --retry-connrefused localhost:3000/places
+          sleep 5
+          # check the server runs at all
+          curl --retry 5 --retry-all-errors localhost:3000/places
+          # check Paris Gare de l’Est exists
+          curl localhost:3000/places/8711300 | jq -e '.places.[0] | select (.name=="Paris Gare de l’Est")'
+          # check Paris Gare de l’Est is found for correct location
+          curl -X POST -H "Content-Type: application/json" -d '{"restrictions": {"numberOfResults": 3}, "placeInput": {"geoPosition": {"latitude": 48.877, "longitude": 2.358}}}' localhost:3000/places | jq -e '.places.[] | select (.name=="Paris Gare de l’Est")'

--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -6,8 +6,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  smoke_test:
+    name: "Smoke-test the Docker image"
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/smoke-test
+
+  build:
+    name: "Release new version to Docker Hub"
+    runs-on: ubuntu-latest
+    needs: smoke_test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -28,26 +37,6 @@ jobs:
         run: echo "BUILD_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          tags: |
-            mainmatter/restations:latest
-            mainmatter/restations:${{ env.BUILD_DATE }}
-
-      - name: Smoke-test to ensure correctness
-        run: |
-          docker run -d -p 3000:3000 mainmatter/restations:latest
-          sleep 5
-          # check the server runs at all
-          curl --retry 5 --retry-all-errors localhost:3000/places
-          # check Paris Gare de l’Est exists
-          curl localhost:3000/places/8711300 | jq -e '.places.[0] | select (.name=="Paris Gare de l’Est")'
-          # check Paris Gare de l’Est is found for correct location
-          curl -X POST -H "Content-Type: application/json" -d '{"restrictions": {"numberOfResults": 3}, "placeInput": {"geoPosition": {"latitude": 48.877, "longitude": 2.358}}}' localhost:3000/places | jq -e '.places.[] | select (.name=="Paris Gare de l’Est")'
-
-      - name: Push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -27,7 +27,27 @@ jobs:
       - name: Set build date
         run: echo "BUILD_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: Build and push Docker image
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: |
+            mainmatter/restations:latest
+            mainmatter/restations:${{ env.BUILD_DATE }}
+
+      - name: Smoke-test to ensure correctness
+        run: |
+          docker run -d -p 3000:3000 mainmatter/restations:latest
+          sleep 5
+          # check the server runs at all
+          curl --retry 5 --retry-all-errors localhost:3000/places
+          # check Paris Gare de l’Est exists
+          curl localhost:3000/places/8711300 | jq -e '.places.[0] | select (.name=="Paris Gare de l’Est")'
+          # check Paris Gare de l’Est is found for correct location
+          curl -X POST -H "Content-Type: application/json" -d '{"restrictions": {"numberOfResults": 3}, "placeInput": {"geoPosition": {"latitude": 48.877, "longitude": 2.358}}}' localhost:3000/places | jq -e '.places.[] | select (.name=="Paris Gare de l’Est")'
+
+      - name: Push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ COPY --chown=restations:restations ./stations.sqlite.db .
 ENV APP_ENVIRONMENT=production
 ENV APP_SERVER__PORT=3000
 ENV APP_SERVER__IP="0.0.0.0"
-ENV APP_DATABASE__URL="${DATABASE_URL}"
+ENV APP_DATABASE__URL="sqlite:stations.sqlite.db"
 ENTRYPOINT ["/usr/local/bin/restations-web"]
 EXPOSE 3000


### PR DESCRIPTION
The `DATABASE_URL` env var can't be reused from a previous build stage…

Also, this improves the smoke tests for the Docker to include some basic testing to ensure the correctness of the data.

Finally, this adds the smoke-testing to the job that publishes the docker container so we don't publish bad versions