### PR TITLE
Release x86 and arm images

### DIFF
--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             mainmatter/restations:latest
             mainmatter/restations:${{ env.BUILD_DATE }}


### PR DESCRIPTION
…so this is more widely usable and we don't see this anymore locally:

```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```