### PR TITLE
Addtl. place data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "liquid",
  "reqwest",
  "restations-config",
+ "serde_json",
  "sqlx",
  "tempfile",
  "tokio",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,8 @@ guppy = "0.17"
 include_dir = "0.7"
 liquid = "~0.26"
 restations-config = { path = "../config" }
-reqwest = { version = "0.12", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream", "json"] }
+serde_json = "1.0"
 sqlx = { version = "0.8", features = [
     "runtime-tokio",
     "tls-rustls",

--- a/cli/src/bin/db.rs
+++ b/cli/src/bin/db.rs
@@ -174,24 +174,6 @@ struct StationRecord {
     pub latitude: Option<f64>,
     pub longitude: Option<f64>,
     pub country: Option<String>,
-    pub info_de: Option<String>,
-    pub info_en: Option<String>,
-    pub info_es: Option<String>,
-    pub info_fr: Option<String>,
-    pub info_it: Option<String>,
-    pub info_nb: Option<String>,
-    pub info_nl: Option<String>,
-    pub info_cs: Option<String>,
-    pub info_da: Option<String>,
-    pub info_hu: Option<String>,
-    pub info_ja: Option<String>,
-    pub info_ko: Option<String>,
-    pub info_pl: Option<String>,
-    pub info_pt: Option<String>,
-    pub info_ru: Option<String>,
-    pub info_sv: Option<String>,
-    pub info_tr: Option<String>,
-    pub info_zh: Option<String>,
 }
 
 async fn sync(config: &Config) -> Result<i32, anyhow::Error> {
@@ -225,28 +207,10 @@ async fn sync(config: &Config) -> Result<i32, anyhow::Error> {
                 uic,
                 latitude,
                 longitude,
-                country,
-                info_de,
-                info_en,
-                info_es,
-                info_fr,
-                info_it,
-                info_nb,
-                info_nl,
-                info_cs,
-                info_da,
-                info_hu,
-                info_ja,
-                info_ko,
-                info_pl,
-                info_pt,
-                info_ru,
-                info_sv,
-                info_tr,
-                info_zh
+                country
             )
             VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?
             )
             "#,
         )
@@ -256,24 +220,6 @@ async fn sync(config: &Config) -> Result<i32, anyhow::Error> {
         .bind(station.latitude)
         .bind(station.longitude)
         .bind(station.country)
-        .bind(station.info_de)
-        .bind(station.info_en)
-        .bind(station.info_es)
-        .bind(station.info_fr)
-        .bind(station.info_it)
-        .bind(station.info_nb)
-        .bind(station.info_nl)
-        .bind(station.info_cs)
-        .bind(station.info_da)
-        .bind(station.info_hu)
-        .bind(station.info_ja)
-        .bind(station.info_ko)
-        .bind(station.info_pl)
-        .bind(station.info_pt)
-        .bind(station.info_ru)
-        .bind(station.info_sv)
-        .bind(station.info_tr)
-        .bind(station.info_zh)
         .execute(&mut conn)
         .await?;
         i += 1;
@@ -306,29 +252,9 @@ fn prepare_station(record: StringRecord, i: i32) -> Result<StationRecord, anyhow
     let lat = record.get(5);
     let lon = record.get(6);
     let country = record.get(8);
-    let info_de = record.get(54);
-    let info_en = record.get(55);
-    let info_es = record.get(56);
-    let info_fr = record.get(57);
-    let info_it = record.get(58);
-    let info_nb = record.get(59);
-    let info_nl = record.get(60);
-    let info_cs = record.get(61);
-    let info_da = record.get(62);
-    let info_hu = record.get(63);
-    let info_ja = record.get(64);
-    let info_ko = record.get(65);
-    let info_pl = record.get(66);
-    let info_pt = record.get(67);
-    let info_ru = record.get(68);
-    let info_sv = record.get(69);
-    let info_tr = record.get(70);
-    let info_zh = record.get(71);
 
     match (
-        id, name, uic, lat, lon, country, info_de, info_en, info_es, info_fr, info_it, info_nb,
-        info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv,
-        info_tr, info_zh,
+        id, name, uic, lat, lon, country
     ) {
         (
             Some(id),
@@ -337,24 +263,6 @@ fn prepare_station(record: StringRecord, i: i32) -> Result<StationRecord, anyhow
             Some(lat),
             Some(lon),
             Some(country),
-            Some(info_de),
-            Some(info_en),
-            Some(info_es),
-            Some(info_fr),
-            Some(info_it),
-            Some(info_nb),
-            Some(info_nl),
-            Some(info_cs),
-            Some(info_da),
-            Some(info_hu),
-            Some(info_ja),
-            Some(info_ko),
-            Some(info_pl),
-            Some(info_pt),
-            Some(info_ru),
-            Some(info_sv),
-            Some(info_tr),
-            Some(info_zh),
         ) => {
             let id = id
                 .parse::<i64>()
@@ -383,24 +291,6 @@ fn prepare_station(record: StringRecord, i: i32) -> Result<StationRecord, anyhow
                 latitude: lat,
                 longitude: lon,
                 country: prepare_csv_string(country),
-                info_de: prepare_csv_string(info_de),
-                info_en: prepare_csv_string(info_en),
-                info_es: prepare_csv_string(info_es),
-                info_fr: prepare_csv_string(info_fr),
-                info_it: prepare_csv_string(info_it),
-                info_nb: prepare_csv_string(info_nb),
-                info_nl: prepare_csv_string(info_nl),
-                info_cs: prepare_csv_string(info_cs),
-                info_da: prepare_csv_string(info_da),
-                info_hu: prepare_csv_string(info_hu),
-                info_ja: prepare_csv_string(info_ja),
-                info_ko: prepare_csv_string(info_ko),
-                info_pl: prepare_csv_string(info_pl),
-                info_pt: prepare_csv_string(info_pt),
-                info_ru: prepare_csv_string(info_ru),
-                info_sv: prepare_csv_string(info_sv),
-                info_tr: prepare_csv_string(info_tr),
-                info_zh: prepare_csv_string(info_zh),
             })
         }
         _ => Err(anyhow!("Invalid data in line {}!", i)),

--- a/cli/src/bin/db.rs
+++ b/cli/src/bin/db.rs
@@ -197,6 +197,9 @@ async fn sync(config: &Config) -> Result<i32, anyhow::Error> {
         let record = record.context("Failed to read record from CSV file!")?;
         let station = prepare_station(record, i)?;
 
+        // TODO: get name (all languages), country name (all languages), country code, postcode, city (all languages), display name (all languages), street (all languages)
+        // localhost:8080/reverse?format=jsonv2&lat=48.876742&lon=2.358424&addressdetails=1&namedetails=1
+
         sqlx::query(
             r#"
             INSERT INTO

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,7 +4,8 @@ CREATE TABLE stations (
     uic TEXT NOT NULL,
     latitude REAL,
     longitude REAL,
-    country TEXT
+    country TEXT,
+    data JSON
 );
 
 CREATE UNIQUE INDEX stations_id_idx ON stations (id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,25 +4,7 @@ CREATE TABLE stations (
     uic TEXT NOT NULL,
     latitude REAL,
     longitude REAL,
-    country TEXT,
-    info_de TEXT,
-    info_en TEXT,
-    info_es TEXT,
-    info_fr TEXT,
-    info_it TEXT,
-    info_nb TEXT,
-    info_nl TEXT,
-    info_cs TEXT,
-    info_da TEXT,
-    info_hu TEXT,
-    info_ja TEXT,
-    info_ko TEXT,
-    info_pl TEXT,
-    info_pt TEXT,
-    info_ru TEXT,
-    info_sv TEXT,
-    info_tr TEXT,
-    info_zh TEXT
+    country TEXT
 );
 
 CREATE UNIQUE INDEX stations_id_idx ON stations (id);

--- a/db/src/entities/stations.rs
+++ b/db/src/entities/stations.rs
@@ -20,24 +20,6 @@ pub struct Station {
     pub latitude: Option<f64>,
     pub longitude: Option<f64>,
     pub country: Option<String>,
-    pub info_de: Option<String>,
-    pub info_en: Option<String>,
-    pub info_es: Option<String>,
-    pub info_fr: Option<String>,
-    pub info_it: Option<String>,
-    pub info_nb: Option<String>,
-    pub info_nl: Option<String>,
-    pub info_cs: Option<String>,
-    pub info_da: Option<String>,
-    pub info_hu: Option<String>,
-    pub info_ja: Option<String>,
-    pub info_ko: Option<String>,
-    pub info_pl: Option<String>,
-    pub info_pt: Option<String>,
-    pub info_ru: Option<String>,
-    pub info_sv: Option<String>,
-    pub info_tr: Option<String>,
-    pub info_zh: Option<String>,
 }
 
 #[derive(Deserialize, Validate, Clone)]
@@ -59,24 +41,6 @@ pub struct StationChangeset {
     pub longitude: Option<f64>,
     #[cfg_attr(feature = "test-helpers", dummy(faker = "CountryName()"))]
     pub country: Option<String>,
-    pub info_de: Option<String>,
-    pub info_en: Option<String>,
-    pub info_es: Option<String>,
-    pub info_fr: Option<String>,
-    pub info_it: Option<String>,
-    pub info_nb: Option<String>,
-    pub info_nl: Option<String>,
-    pub info_cs: Option<String>,
-    pub info_da: Option<String>,
-    pub info_hu: Option<String>,
-    pub info_ja: Option<String>,
-    pub info_ko: Option<String>,
-    pub info_pl: Option<String>,
-    pub info_pt: Option<String>,
-    pub info_ru: Option<String>,
-    pub info_sv: Option<String>,
-    pub info_tr: Option<String>,
-    pub info_zh: Option<String>,
 }
 
 pub async fn load_all(
@@ -90,25 +54,7 @@ pub async fn load_all(
             uic,
             latitude,
             longitude,
-            country,
-            info_de,
-            info_en,
-            info_es,
-            info_fr,
-            info_it,
-            info_nb,
-            info_nl,
-            info_cs,
-            info_da,
-            info_hu,
-            info_ja,
-            info_ko,
-            info_pl,
-            info_pt,
-            info_ru,
-            info_sv,
-            info_tr,
-            info_zh
+            country
         FROM
             stations"
     )
@@ -129,25 +75,7 @@ pub async fn load_all_within_limit(
             uic,
             latitude,
             longitude,
-            country,
-            info_de,
-            info_en,
-            info_es,
-            info_fr,
-            info_it,
-            info_nb,
-            info_nl,
-            info_cs,
-            info_da,
-            info_hu,
-            info_ja,
-            info_ko,
-            info_pl,
-            info_pt,
-            info_ru,
-            info_sv,
-            info_tr,
-            info_zh
+            country
         FROM
             stations
         LIMIT
@@ -171,25 +99,7 @@ pub async fn load(
             uic,
             latitude,
             longitude,
-            country,
-            info_de,
-            info_en,
-            info_es,
-            info_fr,
-            info_it,
-            info_nb,
-            info_nl,
-            info_cs,
-            info_da,
-            info_hu,
-            info_ja,
-            info_ko,
-            info_pl,
-            info_pt,
-            info_ru,
-            info_sv,
-            info_tr,
-            info_zh
+            country
         FROM
             stations
         WHERE
@@ -219,49 +129,13 @@ pub async fn search_by_name(
             uic,
             latitude,
             longitude,
-            country,
-            info_de,
-            info_en,
-            info_es,
-            info_fr,
-            info_it,
-            info_nb,
-            info_nl,
-            info_cs,
-            info_da,
-            info_hu,
-            info_ja,
-            info_ko,
-            info_pl,
-            info_pt,
-            info_ru,
-            info_sv,
-            info_tr,
-            info_zh
+            country
         FROM
             stations
         WHERE
             uic IS NOT NULL
         AND (
             name LIKE $1
-            OR info_de LIKE $1
-            OR info_en LIKE $1
-            OR info_es LIKE $1
-            OR info_fr LIKE $1
-            OR info_it LIKE $1
-            OR info_nb LIKE $1
-            OR info_nl LIKE $1
-            OR info_cs LIKE $1
-            OR info_da LIKE $1
-            OR info_hu LIKE $1
-            OR info_ja LIKE $1
-            OR info_ko LIKE $1
-            OR info_pl LIKE $1
-            OR info_pt LIKE $1
-            OR info_ru LIKE $1
-            OR info_sv LIKE $1
-            OR info_tr LIKE $1
-            OR info_zh LIKE $1
         )
         ORDER BY
             name
@@ -298,25 +172,7 @@ pub async fn search_by_position(
             uic,
             latitude,
             longitude,
-            country,
-            info_de,
-            info_en,
-            info_es,
-            info_fr,
-            info_it,
-            info_nb,
-            info_nl,
-            info_cs,
-            info_da,
-            info_hu,
-            info_ja,
-            info_ko,
-            info_pl,
-            info_pt,
-            info_ru,
-            info_sv,
-            info_tr,
-            info_zh
+            country
         FROM
             stations
         WHERE
@@ -367,25 +223,7 @@ pub async fn search_by_name_and_position(
             uic,
             latitude,
             longitude,
-            country,
-            info_de,
-            info_en,
-            info_es,
-            info_fr,
-            info_it,
-            info_nb,
-            info_nl,
-            info_cs,
-            info_da,
-            info_hu,
-            info_ja,
-            info_ko,
-            info_pl,
-            info_pt,
-            info_ru,
-            info_sv,
-            info_tr,
-            info_zh
+            country
         FROM
             stations
         WHERE

--- a/db/src/test_helpers/stations.rs
+++ b/db/src/test_helpers/stations.rs
@@ -8,31 +8,13 @@ pub async fn create(station: StationChangeset, db: &DbPool) -> Result<Station, a
     station.validate()?;
 
     let record = sqlx::query!(
-        "INSERT INTO stations (id, name, uic, latitude, longitude, country, info_de, info_en, info_es, info_fr, info_it, info_nb, info_nl, info_cs, info_da, info_hu, info_ja, info_ko, info_pl, info_pt, info_ru, info_sv, info_tr, info_zh) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
+        "INSERT INTO stations (id, name, uic, latitude, longitude, country) VALUES (?, ?, ?, ?, ?, ?) RETURNING id",
         station.id,
         station.name,
         station.uic,
         station.latitude,
         station.longitude,
         station.country,
-        station.info_de,
-        station.info_en,
-        station.info_es,
-        station.info_fr,
-        station.info_it,
-        station.info_nb,
-        station.info_nl,
-        station.info_cs,
-        station.info_da,
-        station.info_hu,
-        station.info_ja,
-        station.info_ko,
-        station.info_pl,
-        station.info_pt,
-        station.info_ru,
-        station.info_sv,
-        station.info_tr,
-        station.info_zh
     )
     .fetch_one(db)
     .await?;
@@ -44,23 +26,5 @@ pub async fn create(station: StationChangeset, db: &DbPool) -> Result<Station, a
         latitude: station.latitude,
         longitude: station.longitude,
         country: station.country,
-        info_de: station.info_de,
-        info_en: station.info_en,
-        info_es: station.info_es,
-        info_fr: station.info_fr,
-        info_it: station.info_it,
-        info_nb: station.info_nb,
-        info_nl: station.info_nl,
-        info_cs: station.info_cs,
-        info_da: station.info_da,
-        info_hu: station.info_hu,
-        info_ja: station.info_ja,
-        info_ko: station.info_ko,
-        info_pl: station.info_pl,
-        info_pt: station.info_pt,
-        info_ru: station.info_ru,
-        info_sv: station.info_sv,
-        info_tr: station.info_tr,
-        info_zh: station.info_zh,
     })
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  nominatim:
+    image: "mediagis/nominatim:5.1"
+    restart: always
+    environment:
+      PBF_URL: "https://download.geofabrik.de/europe/monaco-latest.osm.pbf"
+      REPLICATION_URL: "https://download.geofabrik.de/europe-updates/"
+      REVERSE_ONLY: true
+      IMPORT_GB_POSTCODES: true
+    volumes:
+      - db:/var/lib/postgresql/16/main
+      - flatnode:/nominatim/flatnode
+    ports:
+      - 8080:8080
+volumes:
+  db:
+  flatnode:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: "mediagis/nominatim:5.1"
     restart: always
     environment:
-      PBF_URL: "https://download.geofabrik.de/europe/monaco-latest.osm.pbf"
+      PBF_URL: "https://download.geofabrik.de/europe-latest.osm.pbf"
       REPLICATION_URL: "https://download.geofabrik.de/europe-updates/"
       REVERSE_ONLY: true
       IMPORT_GB_POSTCODES: true

--- a/web/tests/api/places_test.rs
+++ b/web/tests/api/places_test.rs
@@ -116,8 +116,7 @@ async fn test_search_by_name_with_results_limit_ok(context: &DbTestContext) {
 #[db_test]
 async fn test_search_other_languages(context: &DbTestContext) {
     let mut changeset: stations::StationChangeset = Faker.fake();
-    changeset.name = String::from("Sevilla");
-    changeset.info_fr = Some(String::from("Seville"));
+    changeset.name = String::from("Seville");
     create(changeset.clone(), &context.db_pool).await.unwrap();
 
     let mut changeset: stations::StationChangeset = Faker.fake();


### PR DESCRIPTION
We're using [Nominatim](https://nominatim.org) to get additional data for places in a number of locales as well. That seems to be working fine in general and we can get the data during the syncing step (or in a second, `augment` or whatever step). We'll just need to figure out how and where we run out Nominatim server (we can't use any publicly available APIs because of rate limits) since the dataset is huge (30GB+) so we can's simply spin up a server on CI when the nightly job runs.